### PR TITLE
import detr_head before import CoDeformDETRHead

### DIFF
--- a/mmdet_custom/models/co_detr_heads/__init__.py
+++ b/mmdet_custom/models/co_detr_heads/__init__.py
@@ -3,9 +3,9 @@
 # @FileName: __init__.py
 # @Software: PyCharm
 from .co_atss_head import CoATSSHead
+from .detr_head import DETRHead_Fix
 from .co_deformable_detr_head import CoDeformDETRHead
 from .co_dino_head import CoDINOCoodHead, CoDINOHead
-from .detr_head import DETRHead_Fix
 from .query_denoising import build_dn_generator
 from .transformer import (BaseTransformerLayer_CP, CoDeformableDetrTransformer,
                           CoDeformableDetrTransformerDecoder,


### PR DESCRIPTION
@BubblyYi Thanks for sharing great works!

It is related to #6.

I could import mmdet_custom after this modification.

![image](https://github.com/user-attachments/assets/1a27d080-0fea-4f8f-be84-9883f758dc8c)

